### PR TITLE
updated collection.py to resolve issue #6 on snyk-labs/snyk-tags-tool

### DIFF
--- a/snyk_tags/collection.py
+++ b/snyk_tags/collection.py
@@ -68,7 +68,7 @@ def apply_tags_to_projects(
             badname = 0
             rightname = 0
             for project in projects.get("projects"):
-                if project["name"].startswith(name + "(") or project["name"].startswith(
+                if project["name"] == name or project["name"].startswith(name + "(") or project["name"].startswith(
                     name + ":"
                 ):
                     apply_tag_to_project(


### PR DESCRIPTION
When customBranch is enabled, Snyk Code projects assume the name of TargetName + "(<BranchName>)". Other projects generally consist of TargetName + (in the case of customBranch) "(<BranchName>)" + ":" + path/to/file. Currently, apply_tags_to_projects is only checking for TargetName + either ":" or "(" which solves most use cases, but when customBranch is disabled, Snyk Code projects assume the name of TargetName. 

This PR is intended to add the condition for project name = target name. Attaching screenshots for scenario testing. 
![Screen Shot 2022-11-10 at 5 47 01 PM](https://user-images.githubusercontent.com/104465262/201231551-c7392f74-54e9-4a13-98ab-9a84998e523c.png)
![Screen Shot 2022-11-10 at 5 48 03 PM](https://user-images.githubusercontent.com/104465262/201231553-e7531a41-ca06-410a-a5bf-ab252fa946e0.png)
![Screen Shot 2022-11-10 at 5 48 24 PM](https://user-images.githubusercontent.com/104465262/201231555-405ae787-a854-4c2c-8ec9-7a6c0ecd1182.png)
![Screen Shot 2022-11-10 at 5 53 26 PM](https://user-images.githubusercontent.com/104465262/201231556-7e8e804b-83bf-471c-b883-87a3eff3edf9.png)
![Screen Shot 2022-11-10 at 5 54 48 PM](https://user-images.githubusercontent.com/104465262/201231558-279ad150-52a6-4705-a46c-c2c26150c618.png)
 