### PR TITLE
fix: contain name escape backslash

### DIFF
--- a/snyk_tags/remove.py
+++ b/snyk_tags/remove.py
@@ -55,7 +55,7 @@ def remove_tags_from_projects(
 def remove_tags_from_projects_by_name(
     token: str, org_id: str, name: str, ignorecase: bool, tag: str, key: str
 ) -> None:
-    exp = name + "+"
+    exp = name.replace('\\', '\\\\') + "+"
     p = re.compile(exp, re.IGNORECASE) if ignorecase else re.compile(exp)
     client = SnykClient(token=token)
     projects = client.organizations.get(org_id).projects.all()

--- a/snyk_tags/tag.py
+++ b/snyk_tags/tag.py
@@ -103,7 +103,7 @@ def apply_tags_to_projects(
 def apply_tags_to_projects_by_name(
     token: str, org_ids: list, name: str, ignorecase: bool, tag: str, key: str
 ) -> None:
-    exp = name + "+"
+    exp = name.replace('\\', '\\\\') + "+"
     p = re.compile(exp, re.IGNORECASE) if ignorecase else re.compile(exp)
     with create_client(token=token) as client:
         for org_id in org_ids:


### PR DESCRIPTION

escape backslash in contain-name search string

**Testcase**

```
(snyk-tags-xVW0Mbl0-py3.9) gwunleong@gwunleongs-MBP snyk-tags-tool % python3 -m snyk_tags tag alltargets --contains-name="io.snyk\log4shell\server" --group-id=ff0c78bb-6365-462c-8576-e73de8793870 --org-id=84a533fd-4686-451f-9c36-af3b30332670 --tagkey=app-microservice --tagvalue=io-snyk-log4shell

Adding the tag key app-microservice and tag value io-snyk-log4shell to io.snyk\log4shell\server projects in Snyk for easy filtering via the UI
Successfully added io-snyk-log4shell tag to Project: c:\io.snyk\log4shell\server.

(snyk-tags-xVW0Mbl0-py3.9) gwunleong@gwunleongs-MBP snyk-tags-tool % python3 -m snyk_tags remove tag-from-alltargets --contains-name="io.snyk\log4shell\server"  --org-id=84a533fd-4686-451f-9c36-af3b30332670 --tagkey=app-microservice --tagvalue=io-snyk-log4shell 

Removing app-microservice:io-snyk-log4shell from projects within 84a533fd-4686-451f-9c36-af3b30332670
Removing tag app-microservice:io-snyk-log4shell from c:\io.snyk\log4shell\server
```