### PR TITLE
feat: add component command

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -175,7 +175,7 @@ socks = ["socksio (>=1.0.0,<2.0.0)"]
 
 [[package]]
 name = "httpx"
-version = "0.23.0"
+version = "0.24.1"
 description = "The next generation HTTP client."
 category = "main"
 optional = false
@@ -183,13 +183,13 @@ python-versions = ">=3.7"
 
 [package.dependencies]
 certifi = "*"
-httpcore = ">=0.15.0,<0.16.0"
-rfc3986 = {version = ">=1.3,<2", extras = ["idna2008"]}
+httpcore = ">=0.15.0,<0.18.0"
+idna = "*"
 sniffio = "*"
 
 [package.extras]
 brotli = ["brotli", "brotlicffi"]
-cli = ["click (>=8.0.0,<9.0.0)", "pygments (>=2.0.0,<3.0.0)", "rich (>=10,<13)"]
+cli = ["click (>=8.0.0,<9.0.0)", "pygments (>=2.0.0,<3.0.0)", "rich (>=10,<14)"]
 http2 = ["h2 (>=3,<5)"]
 socks = ["socksio (>=1.0.0,<2.0.0)"]
 
@@ -439,6 +439,21 @@ tomli = {version = ">=1.0.0", markers = "python_version < \"3.11\""}
 testing = ["argcomplete", "attrs (>=19.2.0)", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
 
 [[package]]
+name = "pytest-httpx"
+version = "0.22.0"
+description = "Send responses to httpx."
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+httpx = ">=0.24.0,<0.25.0"
+pytest = ">=6.0,<8.0"
+
+[package.extras]
+testing = ["pytest-asyncio (>=0.20.0,<0.21.0)", "pytest-cov (>=4.0.0,<5.0.0)"]
+
+[[package]]
 name = "pyyaml"
 version = "6.0.1"
 description = "YAML parser and emitter for Python"
@@ -475,20 +490,6 @@ python-versions = "*"
 [package.dependencies]
 decorator = ">=3.4.2"
 py = ">=1.4.26,<2.0.0"
-
-[[package]]
-name = "rfc3986"
-version = "1.5.0"
-description = "Validating URI References per RFC 3986"
-category = "main"
-optional = false
-python-versions = "*"
-
-[package.dependencies]
-idna = {version = "*", optional = true, markers = "extra == \"idna2008\""}
-
-[package.extras]
-idna2008 = ["idna"]
 
 [[package]]
 name = "rich"
@@ -591,7 +592,7 @@ testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools"
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7,<4.0"
-content-hash = "c486d1f287e7a73927369bf12e4dda97c098bd14a3d4a3d7eb082540f1b39b40"
+content-hash = "3ca1b2f7944f32d9c033a1033688a7588dece1d2af5f7c2e885f3fb3890ddb29"
 
 [metadata.files]
 anyio = [
@@ -717,8 +718,8 @@ httpcore = [
     {file = "httpcore-0.15.0.tar.gz", hash = "sha256:18b68ab86a3ccf3e7dc0f43598eaddcf472b602aba29f9aa6ab85fe2ada3980b"},
 ]
 httpx = [
-    {file = "httpx-0.23.0-py3-none-any.whl", hash = "sha256:42974f577483e1e932c3cdc3cd2303e883cbfba17fe228b0f63589764d7b9c4b"},
-    {file = "httpx-0.23.0.tar.gz", hash = "sha256:f28eac771ec9eb4866d3fb4ab65abd42d38c424739e80c08d8d20570de60b0ef"},
+    {file = "httpx-0.24.1-py3-none-any.whl", hash = "sha256:06781eb9ac53cde990577af654bd990a4949de37a28bdb4a230d434f3a30b9bd"},
+    {file = "httpx-0.24.1.tar.gz", hash = "sha256:5853a43053df830c20f8110c5e69fe44d035d850b2dfe795e196f00fdb774bdd"},
 ]
 idna = [
     {file = "idna-3.4-py3-none-any.whl", hash = "sha256:90b77e79eaa3eba6de819a0c442c0b4ceefc341a7a2ab77d7562bf49f425c5c2"},
@@ -829,6 +830,10 @@ pytest = [
     {file = "pytest-7.4.0-py3-none-any.whl", hash = "sha256:78bf16451a2eb8c7a2ea98e32dc119fd2aa758f1d5d66dbf0a59d69a3969df32"},
     {file = "pytest-7.4.0.tar.gz", hash = "sha256:b4bf8c45bd59934ed84001ad51e11b4ee40d40a1229d2c79f9c592b0a3f6bd8a"},
 ]
+pytest-httpx = [
+    {file = "pytest_httpx-0.22.0-py3-none-any.whl", hash = "sha256:cefb7dcf66a4cb0601b0de05e576cca423b6081f3245e7912a4d84c58fa3eae8"},
+    {file = "pytest_httpx-0.22.0.tar.gz", hash = "sha256:3a82797f3a9a14d51e8c6b7fa97524b68b847ee801109c062e696b4744f4431c"},
+]
 pyyaml = [
     {file = "PyYAML-6.0.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:d858aa552c999bc8a8d57426ed01e40bef403cd8ccdd0fc5f6f04a00414cac2a"},
     {file = "PyYAML-6.0.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:fd66fc5d0da6d9815ba2cebeb4205f95818ff4b79c3ebe268e75d961704af52f"},
@@ -878,10 +883,6 @@ requests = [
 retry = [
     {file = "retry-0.9.2-py2.py3-none-any.whl", hash = "sha256:ccddf89761fa2c726ab29391837d4327f819ea14d244c232a1d24c67a2f98606"},
     {file = "retry-0.9.2.tar.gz", hash = "sha256:f8bfa8b99b69c4506d6f5bd3b0aabf77f98cdb17f3c9fc3f5ca820033336fba4"},
-]
-rfc3986 = [
-    {file = "rfc3986-1.5.0-py2.py3-none-any.whl", hash = "sha256:a86d6e1f5b1dc238b218b012df0aa79409667bb209e58da56d0b94704e712a97"},
-    {file = "rfc3986-1.5.0.tar.gz", hash = "sha256:270aaf10d87d0d4e095063c65bf3ddbc6ee3d0b226328ce21e036f946e421835"},
 ]
 rich = [
     {file = "rich-12.6.0-py3-none-any.whl", hash = "sha256:a4eb26484f2c82589bd9a17c73d32a010b1e29d89f1604cd9bf3a2097b81bb5e"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ snyk-tags = "snyk_tags.tags:app"
 [tool.poetry.dependencies]
 python = ">=3.7,<4.0"
 typer = ">=0.5.0"
-httpx = "^0.23.0"
+httpx = "^0.24.0"
 colorama = "^0.4.5"
 shellingham = "^1.4.0"
 rich = ">=10.11.0"
@@ -29,6 +29,9 @@ requests = "2.31.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.4"
+
+[tool.poetry.group.dev.dependencies]
+pytest-httpx = "^0.22.0"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/snyk_tags/component.py
+++ b/snyk_tags/component.py
@@ -1,0 +1,120 @@
+#! /usr/bin/env python3
+
+import logging
+import httpx
+import typer
+from rich import print
+
+from snyk_tags import __app_name__, __version__
+from snyk_tags.lib.api import Api
+from snyk_tags.lib.component_rules import parse_rules, project_matcher
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(message)s",
+    datefmt="[%X]",
+)
+
+app = typer.Typer()
+
+
+@app.command(help=f"Manage software component project tags")
+def tag(
+    rules: str = typer.Argument(...),
+    org_id: str = typer.Option(
+        ...,  # Default value of comamand
+        envvar=["ORG_ID"],
+        help="Specify the Organization ID where you want to apply the tag",
+    ),
+    snyktkn: str = typer.Option(
+        ...,  # Default value of comamand
+        help="Snyk API token with org admin access",
+        envvar=["SNYK_TOKEN"],
+    ),
+    dry_run: bool = typer.Option(
+        default=False,
+        help="Dry run",
+    ),
+    remove: bool = typer.Option(
+        default=False,
+        help="Remove matching component tags defined by rules",
+    ),
+    exclusive: bool = typer.Option(
+        default=False,
+        help="Remove all other component tags from projects. When used in combination with --remove, all component tags are removed from matching projects.",
+    ),
+):
+    with open(rules, "r") as f:
+        rules_doc = parse_rules(f)
+        (match_fn, context) = project_matcher(rules_doc)
+        client = Api(snyktkn)
+        for project in client.org_projects(org_id):
+            # Extract and transform project and target data from API response
+            # for rule input. Rules operate over project attributes, extended
+            # with a "target" object property derived from the related target's
+            # attributes.
+            project_obj = {}
+            project_obj.update(**project.get("attributes", {}))
+            target = (
+                project.get("relationships", {}).get("target", {}).get("attributes")
+            )
+            if target:
+                project_obj.update(target=target)
+
+            # Clear context as this dict is (re)used in-place with each
+            # execution of the project matcher rules.
+            context.clear()
+            component = match_fn(project.get("attributes", {}))
+            if not component:
+                # Rule did not match
+                continue
+
+            # Interpolate matcher context values, if any were extracted
+            component = component.format(**context)
+
+            have_component_tag = any(
+                tag.get("value")
+                for tag in project.get("attributes", {}).get("tags", [])
+                if tag.get("key") == "component" and tag.get("value") == component
+            )
+            other_component_tags = set(
+                tag.get("value")
+                for tag in project.get("attributes", {}).get("tags", [])
+                if tag.get("key") == "component" and tag.get("value") != component
+            )
+
+            if exclusive:
+                for other_component in other_component_tags:
+                    print(
+                        f"""{dry_run and "would remove" or "removing"} other tag "component:{other_component}" from project id="{project["id"]}" name="{project_obj["name"]}" (exclusive)"""
+                    )
+                    client.remove_project_tag(
+                        org_id,
+                        project["id"],
+                        tag={"key": "component", "value": other_component},
+                    )
+
+            if remove:
+                if have_component_tag:
+                    print(
+                        f"""{dry_run and "would remove" or "removing"} tag "component:{component}" from project id="{project["id"]}" name="{project_obj["name"]}\""""
+                    )
+                    client.remove_project_tag(
+                        org_id,
+                        project["id"],
+                        tag={"key": "component", "value": component},
+                    )
+            else:
+                if not have_component_tag:
+                    print(
+                        f"""{dry_run and "would add" or "adding"} tag "component:{component}" to project id="{project["id"]}" name="{project_obj["name"]}\""""
+                    )
+                    client.add_project_tag(
+                        org_id,
+                        project["id"],
+                        tag={"key": "component", "value": component},
+                    )
+                else:
+                    print(
+                        f"""tag "component:{component}" already present on project id="{project["id"]}" name="{project_obj["name"]}\""""
+                    )

--- a/snyk_tags/tags.py
+++ b/snyk_tags/tags.py
@@ -3,7 +3,7 @@
 import typer
 
 from typing import Optional
-from snyk_tags import __app_name__, __version__, files, list, collection, tag, remove
+from snyk_tags import __app_name__, __version__, files, list, collection, tag, remove, component
 
 snyk = typer.style("snyk-tags", bold=True)
 snykcmd = typer.style("snyk-tags tag --help", bold=True, fg=typer.colors.MAGENTA)
@@ -38,6 +38,11 @@ app.add_typer(
     files.app,
     name="fromfile",
     help="Import tags and attributes from a csv file to a target e.g. Git repo",
+)
+app.add_typer(
+    component.app,
+    name="component",
+    help="Manage software component definitions with Snyk project tags",
 )
 
 

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -1,0 +1,373 @@
+import os
+import re
+
+# Necessary to ensure consistent stdout contents from typer.
+# Otherwise asserts below could fail due to terminal width!
+os.environ["COLUMNS"] = "132"
+
+import pytest
+from typer.testing import CliRunner
+
+from snyk_tags import tags
+
+runner = CliRunner()
+app = tags.app
+
+
+@pytest.fixture
+def assert_all_responses_were_requested() -> bool:
+    return False
+
+
+def test_component_tag_match_dry_run(tmpdir, httpx_mock):
+    rules_file = tmpdir.join("rules.yaml")
+    rules_file.write(
+        """
+version: 1
+rules:
+  - name: test
+    projects:
+      - name: test
+    component: test-component
+"""
+    )
+    httpx_mock.add_response(
+        method="GET",
+        url=re.compile("^.*/orgs/some-org/projects[?].*"),
+        json={
+            "data": [
+                {
+                    "id": "some-project",
+                    "attributes": {
+                        "name": "test",
+                    },
+                },
+            ],
+        },
+    )
+    httpx_mock.add_response(
+        method="POST", url=re.compile("^.*/org/some-org/project/some-project/tags$")
+    )
+    httpx_mock.add_response(
+        status_code=400
+    )  # catch-all response, otherwise backoff retry will block testing
+
+    result = runner.invoke(
+        app,
+        [
+            "component",
+            "tag",
+            "--org-id",
+            "some-org",
+            "--snyktkn",
+            "some-token",
+            "--dry-run",
+            str(rules_file),
+        ],
+    )
+    assert result.exit_code == 0
+    assert (
+        """would add tag "component:test-component" to project id="some-project" name="test\""""
+        in result.stdout
+    )
+
+
+def test_component_tag_match_added(tmpdir, httpx_mock):
+    rules_file = tmpdir.join("rules.yaml")
+    rules_file.write(
+        """
+version: 1
+rules:
+  - name: test
+    projects:
+      - name: test
+    component: test-component
+"""
+    )
+    httpx_mock.add_response(
+        method="GET",
+        url=re.compile("^.*/orgs/some-org/projects[?].*"),
+        json={
+            "data": [
+                {
+                    "id": "some-project",
+                    "attributes": {
+                        "name": "test",
+                    },
+                },
+            ],
+        },
+    )
+    httpx_mock.add_response(
+        method="POST", url=re.compile("^.*/org/some-org/project/some-project/tags$")
+    )
+    httpx_mock.add_response(
+        status_code=400
+    )  # catch-all response, otherwise backoff retry will block testing
+
+    result = runner.invoke(
+        app,
+        [
+            "component",
+            "tag",
+            "--org-id",
+            "some-org",
+            "--snyktkn",
+            "some-token",
+            str(rules_file),
+        ],
+    )
+    assert result.exit_code == 0
+    assert (
+        """adding tag "component:test-component" to project id="some-project" name="test\""""
+        in result.stdout
+    )
+
+
+def test_component_tag_match_already_tagged(tmpdir, httpx_mock):
+    rules_file = tmpdir.join("rules.yaml")
+    rules_file.write(
+        """
+version: 1
+rules:
+  - name: test
+    projects:
+      - name: test
+    component: test-component
+"""
+    )
+    httpx_mock.add_response(
+        method="GET",
+        url=re.compile("^.*/orgs/some-org/projects[?].*"),
+        json={
+            "data": [
+                {
+                    "id": "some-project",
+                    "attributes": {
+                        "name": "test",
+                        "tags": [{"key": "component", "value": "test-component"}],
+                    },
+                },
+            ],
+        },
+    )
+    httpx_mock.add_response(
+        method="POST", url=re.compile("^.*/org/some-org/project/some-project/tags$")
+    )
+    httpx_mock.add_response(
+        status_code=400
+    )  # catch-all response, otherwise backoff retry will block testing
+
+    result = runner.invoke(
+        app,
+        [
+            "component",
+            "tag",
+            "--org-id",
+            "some-org",
+            "--snyktkn",
+            "some-token",
+            str(rules_file),
+        ],
+    )
+    assert result.exit_code == 0
+    assert (
+        """tag "component:test-component" already present on project id="some-project" name="test\""""
+        in result.stdout
+    )
+
+
+def test_component_tag_match_exclusive(tmpdir, httpx_mock):
+    rules_file = tmpdir.join("rules.yaml")
+    rules_file.write(
+        """
+version: 1
+rules:
+  - name: test
+    projects:
+      - name: test
+    component: test-component
+"""
+    )
+    httpx_mock.add_response(
+        method="GET",
+        url=re.compile("^.*/orgs/some-org/projects[?].*"),
+        json={
+            "data": [
+                {
+                    "id": "some-project",
+                    "attributes": {
+                        "name": "test",
+                        "tags": [{"key": "component", "value": "other-component"}],
+                    },
+                },
+            ],
+        },
+    )
+    httpx_mock.add_response(
+        method="POST", url=re.compile("^.*/org/some-org/project/some-project/tags$")
+    )
+    httpx_mock.add_response(
+        method="POST",
+        url=re.compile("^.*/org/some-org/project/some-project/tags/remove$"),
+    )
+    httpx_mock.add_response(
+        status_code=400
+    )  # catch-all response, otherwise backoff retry will block testing
+
+    result = runner.invoke(
+        app,
+        [
+            "component",
+            "tag",
+            "--org-id",
+            "some-org",
+            "--snyktkn",
+            "some-token",
+            "--exclusive",
+            str(rules_file),
+        ],
+    )
+    assert result.exit_code == 0
+    print(result.stdout)
+    assert (
+        """removing other tag "component:other-component" from project id="some-project" name="test" (exclusive)"""
+        in result.stdout
+    )
+    assert (
+        """adding tag "component:test-component" to project id="some-project" name="test\""""
+        in result.stdout
+    )
+
+
+def test_component_tag_match_remove(tmpdir, httpx_mock):
+    rules_file = tmpdir.join("rules.yaml")
+    rules_file.write(
+        """
+version: 1
+rules:
+  - name: test
+    projects:
+      - name: test
+    component: test-component
+"""
+    )
+    httpx_mock.add_response(
+        method="GET",
+        url=re.compile("^.*/orgs/some-org/projects[?].*"),
+        json={
+            "data": [
+                {
+                    "id": "some-project",
+                    "attributes": {
+                        "name": "test",
+                        "tags": [
+                            {"key": "component", "value": "other-component"},
+                            {"key": "component", "value": "test-component"},
+                        ],
+                    },
+                },
+            ],
+        },
+    )
+    httpx_mock.add_response(
+        method="POST", url=re.compile("^.*/org/some-org/project/some-project/tags$")
+    )
+    httpx_mock.add_response(
+        method="POST",
+        url=re.compile("^.*/org/some-org/project/some-project/tags/remove$"),
+    )
+    httpx_mock.add_response(
+        status_code=400
+    )  # catch-all response, otherwise backoff retry will block testing
+
+    result = runner.invoke(
+        app,
+        [
+            "component",
+            "tag",
+            "--org-id",
+            "some-org",
+            "--snyktkn",
+            "some-token",
+            "--remove",
+            str(rules_file),
+        ],
+    )
+    assert result.exit_code == 0
+    assert (
+        """removing tag "component:test-component" from project id="some-project" name="test\""""
+        in result.stdout
+    )
+
+
+def test_component_tag_match_remove_exclusive(tmpdir, httpx_mock):
+    rules_file = tmpdir.join("rules.yaml")
+    rules_file.write(
+        """
+version: 1
+rules:
+  - name: test
+    projects:
+      - name: test
+    component: test-component
+"""
+    )
+    httpx_mock.add_response(
+        method="GET",
+        url=re.compile("^.*/orgs/some-org/projects[?].*"),
+        json={
+            "data": [
+                {
+                    "id": "some-project",
+                    "attributes": {
+                        "name": "test",
+                        "tags": [
+                            {"key": "component", "value": "other-component"},
+                            {"key": "component", "value": "test-component"},
+                        ],
+                    },
+                },
+            ],
+        },
+    )
+    httpx_mock.add_response(
+        method="POST", url=re.compile("^.*/org/some-org/project/some-project/tags$")
+    )
+    # Note there will be two tag remove calls
+    httpx_mock.add_response(
+        method="POST",
+        url=re.compile("^.*/org/some-org/project/some-project/tags/remove$"),
+    )
+    httpx_mock.add_response(
+        method="POST",
+        url=re.compile("^.*/org/some-org/project/some-project/tags/remove$"),
+    )
+    httpx_mock.add_response(
+        status_code=400
+    )  # catch-all response, otherwise backoff retry will block testing
+
+    result = runner.invoke(
+        app,
+        [
+            "component",
+            "tag",
+            "--org-id",
+            "some-org",
+            "--snyktkn",
+            "some-token",
+            "--remove",
+            "--exclusive",
+            str(rules_file),
+        ],
+    )
+    print(result.stdout)
+    assert result.exit_code == 0
+    assert (
+        """removing other tag "component:other-component" from project id="some-project" name="test" (exclusive)"""
+        in result.stdout
+    )
+    assert (
+        """removing tag "component:test-component" from project id="some-project" name="test\""""
+        in result.stdout
+    )


### PR DESCRIPTION
Add a new subcommand, `snyk-tags component tag <rules.yaml>`, which manages software component: tags across all projects in an org, according to project- and target-matching rules.

Upgrade httpx for compatibility with pytest-httpx mock testing.