### PR TITLE
docs: fix named capturing group in the examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ rules:
       # relationship.
       - target:
           url:
-            regex: 'http://github.com/my-retail-store/(?<service_name>\w+)\.git'
+            regex: 'http://github.com/my-retail-store/(?P<service_name>\w+)\.git'
         origin: cli
 
     # Define the component tag for all matching projects. Snyk recommends a


### PR DESCRIPTION
Fix named capturing group in the examples