### PR TITLE
fix typeError on project name

### DIFF
--- a/snyk_tags/collection.py
+++ b/snyk_tags/collection.py
@@ -86,8 +86,8 @@ def apply_tags_to_projects(
             for project in projects["data"]:
                 if (
                     project["attributes"]["name"] == name
-                    or project["attributes"]["name"](name + "(")
-                    or project["attributes"]["name"](name + ":")
+                    or project["attributes"]["name"].startswith(name + "(")
+                    or project["attributes"]["name"].startswith(name + ":")
                 ):
                     apply_tag_to_project(
                         client=client,


### PR DESCRIPTION
'TypeError: ‘str’ object is not callable' when .startswith is omitted. 