### PR TITLE
Moving query params to address issue with expand=target stacking to the url

### DIFF
--- a/snyk_tags/lib/api.py
+++ b/snyk_tags/lib/api.py
@@ -57,10 +57,9 @@ class Api:
     @backoff.on_exception(backoff.expo, httpx.HTTPError, **backoff_params)
     def org_projects(self, org_id: str):
         with self.v3_client() as c:
-            next = f"/orgs/{org_id}/projects"
-            params = {"expand": "target", "limit": 100}
+            next = f"/orgs/{org_id}/projects?expand=target&limit=100"
             while next:
-                resp = c.get(next, params=params)
+                resp = c.get(next)
                 resp.raise_for_status()
                 assert resp.status_code == 200
                 body = resp.json()


### PR DESCRIPTION
* The target query param was getting stacked on multiple calls to the for-loop when using with `next`
* Adding the query params outside of the loop to prevent this