### PR TITLE
feat: support for additional api filters fromfile

### DIFF
--- a/snyk_tags/collection.py
+++ b/snyk_tags/collection.py
@@ -6,6 +6,7 @@ import httpx
 import typer
 from rich import print
 from snyk import SnykClient
+from typing import Dict
 
 from snyk_tags import __app_name__, __version__, attribute, github
 
@@ -69,7 +70,7 @@ def apply_tag_to_project(
 
 # Tagging loop
 def apply_tags_to_projects(
-    token: str, org_ids: list, name: str, tag: str, key: str, tenant: str
+    token: str, org_ids: list, name: str, tag: str, key: str, tenant: str, filters: Dict[str, any]
 ) -> None:
     with create_client(token=token, tenant=tenant) as client:
         for org_id in org_ids:
@@ -81,7 +82,7 @@ def apply_tags_to_projects(
             client_v3 = SnykClient(
                 token=token, url=base_url, version="2023-08-31~experimental"
             )
-            params = {"limit": 100}
+            params = { "limit": 100, "names_start_with": name, **filters }
             projects = client_v3.get_rest_pages(
                 f"/orgs/{org_id}/projects", params=params
             )

--- a/snyk_tags/files.py
+++ b/snyk_tags/files.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python3
 import typer
 from pathlib import Path
-from typing import List
+from typing import List, Optional
 import csv
 from snyk_tags import collection, attribute, remove
 from rich import print
@@ -37,6 +37,7 @@ def target_tag(
     ),
 ):
     for path in file:
+        filters = {}
         if path.is_file():
             openfile = open(path)
             if ".csv" in openfile.name:
@@ -46,12 +47,13 @@ def target_tag(
                     target = row.get("target")
                     key = row.get("key")
                     value = row.get("value")
+                    filters = { attr: val for attr, val in row.items() if attr in ["target_reference", "origins", "types"]}
                     typer.secho(
                         f"\nAdding the tag key {key} and tag value {value} to projects within {target} for easy filtering via the UI",
                         bold=True,
                     )
                     collection.apply_tags_to_projects(
-                        snyktkn, [org_id], target, value, key, tenant
+                        snyktkn, [org_id], target, value, key, tenant, filters
                     )
                 openfile.close()
             elif ".json" in openfile.name:
@@ -61,12 +63,13 @@ def target_tag(
                     target = row.get("target")
                     key = row.get("key")
                     value = row.get("value")
+                    filters = { attr: val for attr, val in row.items() if attr in ["target_reference", "origins", "types"]}
                     typer.secho(
                         f"\nAdding the tag key {key} and tag value {value} to projects within {target} for easy filtering via the UI",
                         bold=True,
                     )
                     collection.apply_tags_to_projects(
-                        snyktkn, [org_id], target, value, key, tenant
+                        snyktkn, [org_id], target, value, key, tenant, filters
                     )
                 openfile.close()
             else:


### PR DESCRIPTION
This change allows users to provide values for `target_reference`, `origins`, or `types` in the csv or json file definitions to further constrain the projects that tags will be applied to.