### PR TITLE
[PTSB-11] Support filtering for project attributes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,6 @@ dist
 .DS_Store
 **/.DS_Store
 tests/test_codeowners.py
-test.csv
+test*.csv
 TODO
 rules.yml

--- a/snyk_tags/attribute.py
+++ b/snyk_tags/attribute.py
@@ -7,6 +7,7 @@ import httpx
 import typer
 from rich import print
 from snyk import SnykClient
+from typing import Dict
 
 from snyk_tags import __app_name__, __version__
 
@@ -96,6 +97,7 @@ def apply_attributes_to_projects(
     environment: list,
     lifecycle: list,
     tenant: str,
+    filters: Dict[str, any],
 ) -> None:
     with create_client(token=token, tenant=tenant) as client:
         for org_id in org_ids:
@@ -107,7 +109,7 @@ def apply_attributes_to_projects(
             client_v3 = SnykClient(
                 token=token, url=base_url, version="2023-08-31~experimental"
             )
-            params = {"limit": 100}
+            params = {"limit": 100, **filters}
             projects = client_v3.get_rest_pages(
                 f"/orgs/{org_id}/projects", params=params
             )

--- a/snyk_tags/collection.py
+++ b/snyk_tags/collection.py
@@ -88,7 +88,7 @@ def apply_tags_to_projects(
             client_v3 = SnykClient(
                 token=token, url=base_url, version="2023-08-31~experimental"
             )
-            params = {"limit": 100, "names_start_with": name, **filters}
+            params = {"limit": 100, **filters}
             projects = client_v3.get_rest_pages(
                 f"/orgs/{org_id}/projects", params=params
             )

--- a/snyk_tags/files.py
+++ b/snyk_tags/files.py
@@ -105,6 +105,7 @@ def target_attributes(
     ),
 ):
     for path in file:
+        filters = {}
         if path.is_file():
             openfile = open(path)
             if ".csv" in openfile.name:
@@ -115,6 +116,11 @@ def target_attributes(
                     criticality = row.get("criticality")
                     environment = row.get("environment")
                     lifecycle = row.get("lifecycle")
+                    filters = {
+                        attr: val
+                        for attr, val in row.items()
+                        if attr in ["target_reference", "origins", "types"]
+                    }
                     typer.secho(
                         f"\nAdding the attributes {criticality}, {environment} and {lifecycle} to projects within {target} for easy filtering via the UI",
                         bold=True,
@@ -128,6 +134,7 @@ def target_attributes(
                         [environment],
                         [lifecycle],
                         tenant,
+                        filters,
                     )
                 openfile.close()
             elif ".json" in openfile.name:
@@ -138,6 +145,11 @@ def target_attributes(
                     criticality = row.get("criticality")
                     environment = row.get("environment")
                     lifecycle = row.get("lifecycle")
+                    filters = {
+                        attr: val
+                        for attr, val in row.items()
+                        if attr in ["target_reference", "origins", "types"]
+                    }
                     typer.secho(
                         f"\nAdding the attributes {criticality}, {environment} and {lifecycle} to projects within {target} for easy filtering via the UI",
                         bold=True,
@@ -151,6 +163,7 @@ def target_attributes(
                         [environment],
                         [lifecycle],
                         tenant,
+                        filters,
                     )
                 openfile.close()
             else:


### PR DESCRIPTION
- Add filtering for project attributes. Users can provide values for `target_reference`, `origins`, or `types` in the csv or json file. 
- Fix URL encoding bug when a user supplies a target with spaces in it by removing `names_start_with` as a required param

Basically same changes made by @gcmurphy-snyk applied here except for attributes instead of tagging.
https://github.com/snyk-labs/snyk-tags-tool/pull/35 