### PR TITLE
fix: remove-tag-from-group command missing tenant value

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "snyk-tags"
-version = "2.5.0"
+version = "2.5.1"
 description = "CLI tool designed to manage tags and attributes at scale"
 authors = ["EricFernandezSnyk <eric.fernandez@snyk.io>"]
 license = "MIT"

--- a/snyk_tags/attribute.py
+++ b/snyk_tags/attribute.py
@@ -26,7 +26,7 @@ app = typer.Typer()
 def create_client(token: str, tenant: str) -> httpx.Client:
     base_url = (
         f"https://api.{tenant}.snyk.io/v1"
-        if tenant in ["eu", "au"]
+        if tenant in ["eu", "au", "us"]
         else "https://api.snyk.io/v1"
     )
     headers = {"Authorization": f"token {token}", "Content-Type": "application/json"}
@@ -103,7 +103,7 @@ def apply_attributes_to_projects(
         for org_id in org_ids:
             base_url = (
                 f"https://api.{tenant}.snyk.io/rest"
-                if tenant in ["eu", "au"]
+                if tenant in ["eu", "au", "us"]
                 else "https://api.snyk.io/rest"
             )
             client_v3 = SnykClient(

--- a/snyk_tags/collection.py
+++ b/snyk_tags/collection.py
@@ -149,7 +149,7 @@ def tag(
     ),
     tenant: str = typer.Option(
         "",  # Default value of comamand
-        help=f"Defaults to US tenant, add 'eu' or 'au' to use EU or AU tenant, use --tenant to change tenant.",
+        help=f"Defaults to US tenant (app.snyk.io), add 'eu', 'au' or 'us' to use alternative regional tenant. Use --tenant to change tenant.",
     ),
     tagKey: str = typer.Option(
         ..., help="Tag key: identifier of the tag"  # Default value of comamand
@@ -194,7 +194,7 @@ def attributes(
     ),
     tenant: str = typer.Option(
         "",  # Default value of comamand
-        help=f"Defaults to US tenant, add 'eu' or 'au' to use EU or AU tenant, use --tenant to change tenant.",
+        help=f"Defaults to US tenant (app.snyk.io), add 'eu', 'au' or 'us' to use alternative regional tenant. Use --tenant to change tenant.",
     ),
 ):
     typer.secho(

--- a/snyk_tags/collection.py
+++ b/snyk_tags/collection.py
@@ -30,7 +30,7 @@ app.add_typer(
 def create_client(token: str, tenant: str) -> httpx.Client:
     base_url = (
         f"https://api.{tenant}.snyk.io/v1"
-        if tenant in ["eu", "au"]
+        if tenant in ["eu", "au", "us"]
         else "https://api.snyk.io/v1"
     )
     headers = {"Authorization": f"token {token}"}
@@ -82,7 +82,7 @@ def apply_tags_to_projects(
         for org_id in org_ids:
             base_url = (
                 f"https://api.{tenant}.snyk.io/rest"
-                if tenant in ["eu", "au"]
+                if tenant in ["eu", "au", "us"]
                 else "https://api.snyk.io/rest"
             )
             client_v3 = SnykClient(

--- a/snyk_tags/component.py
+++ b/snyk_tags/component.py
@@ -165,12 +165,12 @@ def tag(
             snyktkn,
             v1_url=(
                 f"https://api.{tenant}.snyk.io/v1"
-                if tenant in ["eu", "au"]
+                if tenant in ["eu", "au", "us"]
                 else "https://api.snyk.io/v1"
             ),
             rest_url=(
                 f"https://api.{tenant}.snyk.io/rest"
-                if tenant in ["eu", "au"]
+                if tenant in ["eu", "au", "us"]
                 else "https://api.snyk.io/rest"
             ),
         )

--- a/snyk_tags/component.py
+++ b/snyk_tags/component.py
@@ -148,7 +148,7 @@ def tag(
     ),
     tenant: str = typer.Option(
         "",  # Default value of comamand
-        help=f"Defaults to US tenant, add 'eu' or 'au' to use EU or AU tenant, use --tenant to change tenant.",
+        help=f"Defaults to US tenant (app.snyk.io), add 'eu', 'au' or 'us' to use alternative regional tenant. Use --tenant to change tenant.",
     ),
 ):
     if format == "csv":

--- a/snyk_tags/files.py
+++ b/snyk_tags/files.py
@@ -190,6 +190,10 @@ def remove_tag_from_group(
     snyktkn: str = typer.Option(
         ..., help="Snyk API token with Group admin access", envvar=["SNYK_TOKEN"]
     ),
+    tenant: str = typer.Option(
+        "",  # Default value of comamand
+        help=f"Defaults to US tenant, add 'eu' or 'au' to use EU or AU tenant, use --tenant to change tenant.",
+    ),
     force: bool = typer.Option(
         False,
         "--force",
@@ -208,9 +212,10 @@ def remove_tag_from_group(
                         f"\nRemoving {tagKey}:{tagValue} from Group ID: {group_id}",
                         bold=True,
                     )
-                    remove.remove_tag_from_group(
-                        snyktkn, group_id, force, tagValue, tagKey
-                    )
+                    if tagKey and tagValue:
+                        remove.remove_tag_from_group(
+                            snyktkn, group_id, force, tagValue, tagKey, tenant
+                        )
                 openfile.close()
             elif ".json" in openfile.name:
                 jsonreader = json.load(openfile)
@@ -221,9 +226,10 @@ def remove_tag_from_group(
                         f"\nRemoving {tagKey}:{tagValue} from Group ID: {group_id}",
                         bold=True,
                     )
-                    remove.remove_tag_from_group(
-                        snyktkn, group_id, force, tagValue, tagKey
-                    )
+                    if tagKey and tagValue:
+                        remove.remove_tag_from_group(
+                            snyktkn, group_id, force, tagValue, tagKey, tenant
+                        )
                 openfile.close()
             else:
                 print(
@@ -244,6 +250,10 @@ def remove_tag_from_target(
     snyktkn: str = typer.Option(
         ..., help="Snyk API token with org admin access", envvar=["SNYK_TOKEN"]
     ),
+    tenant: str = typer.Option(
+        "",  # Default value of comamand
+        help=f"Defaults to US tenant, add 'eu' or 'au' to use EU or AU tenant, use --tenant to change tenant.",
+    ),
 ):
     for path in file:
         if path.is_file():
@@ -260,7 +270,7 @@ def remove_tag_from_target(
                         bold=True,
                     )
                     remove.remove_tags_from_projects(
-                        snyktkn, org_id, target, value, key
+                        snyktkn, org_id, target, value, key, tenant
                     )
                 openfile.close()
             elif ".json" in openfile.name:
@@ -275,7 +285,7 @@ def remove_tag_from_target(
                         bold=True,
                     )
                     remove.remove_tags_from_projects(
-                        snyktkn, org_id, target, value, key
+                        snyktkn, org_id, target, value, key, tenant
                     )
                 openfile.close()
             else:

--- a/snyk_tags/files.py
+++ b/snyk_tags/files.py
@@ -33,7 +33,7 @@ def target_tag(
     ),
     tenant: str = typer.Option(
         "",  # Default value of comamand
-        help=f"Defaults to US tenant, add 'eu' or 'au' to use EU or AU tenant, use --tenant to change tenant.",
+        help=f"Defaults to US tenant (app.snyk.io), add 'eu', 'au' or 'us' to use alternative regional tenant. Use --tenant to change tenant.",
     ),
 ):
     for path in file:
@@ -101,7 +101,7 @@ def target_attributes(
     ),
     tenant: str = typer.Option(
         "",  # Default value of comamand
-        help=f"Defaults to US tenant, add 'eu' or 'au' to use EU or AU tenant, use --tenant to change tenant.",
+        help=f"Defaults to US tenant (app.snyk.io), add 'eu', 'au' or 'us' to use alternative regional tenant. Use --tenant to change tenant.",
     ),
 ):
     for path in file:
@@ -192,7 +192,7 @@ def remove_tag_from_group(
     ),
     tenant: str = typer.Option(
         "",  # Default value of comamand
-        help=f"Defaults to US tenant, add 'eu' or 'au' to use EU or AU tenant, use --tenant to change tenant.",
+        help=f"Defaults to US tenant (app.snyk.io), add 'eu', 'au' or 'us' to use alternative regional tenant. Use --tenant to change tenant.",
     ),
     force: bool = typer.Option(
         False,
@@ -252,7 +252,7 @@ def remove_tag_from_target(
     ),
     tenant: str = typer.Option(
         "",  # Default value of comamand
-        help=f"Defaults to US tenant, add 'eu' or 'au' to use EU or AU tenant, use --tenant to change tenant.",
+        help=f"Defaults to US tenant (app.snyk.io), add 'eu', 'au' or 'us' to use alternative regional tenant. Use --tenant to change tenant.",
     ),
 ):
     for path in file:

--- a/snyk_tags/github.py
+++ b/snyk_tags/github.py
@@ -227,7 +227,7 @@ def owners(
     ),
     tenant: str = typer.Option(
         "",  # Default value of comamand
-        help=f"Defaults to US tenant, add 'eu' or 'au' to use EU or AU tenant, use --tenant to change tenant.",
+        help=f"Defaults to US tenant (app.snyk.io), add 'eu', 'au' or 'us' to use alternative regional tenant. Use --tenant to change tenant.",
     ),
     gh_base_url: str = typer.Option(
         "https://api.github.com",
@@ -271,7 +271,7 @@ def topics(
     ),
     tenant: str = typer.Option(
         "",  # Default value of comamand
-        help=f"Defaults to US tenant, add 'eu' or 'au' to use EU or AU tenant, use --tenant to change tenant.",
+        help=f"Defaults to US tenant (app.snyk.io), add 'eu', 'au' or 'us' to use alternative regional tenant. Use --tenant to change tenant.",
     ),
     gh_base_url: str = typer.Option(
         "https://api.github.com",

--- a/snyk_tags/github.py
+++ b/snyk_tags/github.py
@@ -26,7 +26,7 @@ app = typer.Typer()
 def create_client(token: str, tenant: str) -> httpx.Client:
     base_url = (
         f"https://api.{tenant}.snyk.io/v1"
-        if tenant in ["eu", "au"]
+        if tenant in ["eu", "au", "us"]
         else "https://api.snyk.io/v1"
     )
     headers = {"Authorization": f"token {token}"}
@@ -86,7 +86,7 @@ def apply_github_owner_to_repo(
         for org_id in org_ids:
             base_url = (
                 f"https://api.{tenant}.snyk.io/rest"
-                if tenant in ["eu", "au"]
+                if tenant in ["eu", "au", "us"]
                 else "https://api.snyk.io/rest"
             )
             client_v3 = SnykClient(
@@ -156,7 +156,7 @@ def apply_github_topics_to_repo(
         for org_id in org_ids:
             base_url = (
                 f"https://api.{tenant}.snyk.io/rest"
-                if tenant in ["eu", "au"]
+                if tenant in ["eu", "au", "us"]
                 else "https://api.snyk.io/rest"
             )
             client_v3 = SnykClient(

--- a/snyk_tags/list.py
+++ b/snyk_tags/list.py
@@ -71,7 +71,7 @@ def attributes():
 def create_client(token: str, tenant: str) -> httpx.Client:
     base_url = (
         f"https://api.{tenant}.snyk.io/v1"
-        if tenant in ["eu", "au"]
+        if tenant in ["eu", "au", "us"]
         else "https://api.snyk.io/v1"
     )
     headers = {"Authorization": f"token {token}"}

--- a/snyk_tags/list.py
+++ b/snyk_tags/list.py
@@ -115,7 +115,7 @@ def tags(
     ),
     tenant: str = typer.Option(
         "",  # Default value of comamand
-        help=f"Defaults to US tenant, add 'eu' or 'au' to use EU or AU tenant, use --tenant to change tenant.",
+        help=f"Defaults to US tenant (app.snyk.io), add 'eu', 'au' or 'us' to use alternative regional tenant. Use --tenant to change tenant.",
     ),
     json: bool = typer.Option(
         False,

--- a/snyk_tags/remove.py
+++ b/snyk_tags/remove.py
@@ -30,7 +30,7 @@ def remove_tag_from_project(
 ) -> tuple:
     base_url = (
         f"https://api.{tenant}.snyk.io/v1"
-        if tenant in ["eu", "au"]
+        if tenant in ["eu", "au", "us"]
         else "https://api.snyk.io/v1"
     )
     client = SnykClient(token=token, url=base_url)
@@ -54,7 +54,7 @@ def remove_tags_from_projects(
 ) -> None:
     base_url = (
         f"https://api.{tenant}.snyk.io/rest"
-        if tenant in ["eu", "au"]
+        if tenant in ["eu", "au", "us"]
         else "https://api.snyk.io/rest"
     )
     client_v3 = SnykClient(token=token, url=base_url, version="2023-08-31~experimental")
@@ -94,7 +94,7 @@ def remove_tags_from_projects_by_name(
     p = re.compile(exp, re.IGNORECASE) if ignorecase else re.compile(exp)
     base_url = (
         f"https://api.{tenant}.snyk.io/rest"
-        if tenant in ["eu", "au"]
+        if tenant in ["eu", "au", "us"]
         else "https://api.snyk.io/rest"
     )
     client_v3 = SnykClient(token=token, url=base_url, version="2023-08-31~experimental")
@@ -118,7 +118,7 @@ def remove_tags_from_projects_by_name(
 def create_client(token: str, tenant: str) -> httpx.Client:
     base_url = (
         f"https://api.{tenant}.snyk.io/v1"
-        if tenant in ["eu", "au"]
+        if tenant in ["eu", "au", "us"]
         else "https://api.snyk.io/v1"
     )
     headers = {"Authorization": f"token {token}"}

--- a/snyk_tags/remove.py
+++ b/snyk_tags/remove.py
@@ -183,7 +183,7 @@ def tag_from_target(
     ),
     tenant: str = typer.Option(
         "",  # Default value of comamand
-        help=f"Defaults to US tenant, add 'eu' or 'au' to use EU or AU tenant, use --tenant to change tenant.",
+        help=f"Defaults to US tenant (app.snyk.io), add 'eu', 'au' or 'us' to use alternative regional tenant. Use --tenant to change tenant.",
     ),
 ):
     typer.secho(
@@ -223,7 +223,7 @@ def tag_from_alltargets(
     ),
     tenant: str = typer.Option(
         "",  # Default value of comamand
-        help=f"Defaults to US tenant, add 'eu' or 'au' to use EU or AU tenant, use --tenant to change tenant.",
+        help=f"Defaults to US tenant (app.snyk.io), add 'eu', 'au' or 'us' to use alternative regional tenant. Use --tenant to change tenant.",
     ),
 ):
     typer.secho(
@@ -259,7 +259,7 @@ def tag_from_group(
     ),
     tenant: str = typer.Option(
         "",  # Default value of comamand
-        help=f"Defaults to US tenant, add 'eu' or 'au' to use EU or AU tenant, use --tenant to change tenant.",
+        help=f"Defaults to US tenant (app.snyk.io), add 'eu', 'au' or 'us' to use alternative regional tenant. Use --tenant to change tenant.",
     ),
 ):
     typer.secho(f"\nRemoving {tagKey}:{tagValue} from Group ID: {group_id}", bold=True)

--- a/snyk_tags/tag.py
+++ b/snyk_tags/tag.py
@@ -193,7 +193,7 @@ def sast(
     ),
     tenant: str = typer.Option(
         "",  # Default value of comamand
-        help=f"Defaults to US tenant, add 'eu' or 'au' to use EU or AU tenant, use --tenant to change tenant.",
+        help=f"Defaults to US tenant (app.snyk.io), add 'eu', 'au' or 'us' to use alternative regional tenant. Use --tenant to change tenant.",
     ),
     addprojecttype: bool = typer.Option(
         False,
@@ -253,7 +253,7 @@ def iac(
     ),
     tenant: str = typer.Option(
         "",  # Default value of comamand
-        help=f"Defaults to US tenant, add 'eu' or 'au' to use EU or AU tenant, use --tenant to change tenant.",
+        help=f"Defaults to US tenant (app.snyk.io), add 'eu', 'au' or 'us' to use alternative regional tenant. Use --tenant to change tenant.",
     ),
     addprojecttype: bool = typer.Option(
         False,
@@ -322,7 +322,7 @@ def sca(
     ),
     tenant: str = typer.Option(
         "",  # Default value of comamand
-        help=f"Defaults to US tenant, add 'eu' or 'au' to use EU or AU tenant, use --tenant to change tenant.",
+        help=f"Defaults to US tenant (app.snyk.io), add 'eu', 'au' or 'us' to use alternative regional tenant. Use --tenant to change tenant.",
     ),
     addprojecttype: bool = typer.Option(
         False,
@@ -408,7 +408,7 @@ def container(
     ),
     tenant: str = typer.Option(
         "",  # Default value of comamand
-        help=f"Defaults to US tenant, add 'eu' or 'au' to use EU or AU tenant, use --tenant to change tenant.",
+        help=f"Defaults to US tenant (app.snyk.io), add 'eu', 'au' or 'us' to use alternative regional tenant. Use --tenant to change tenant.",
     ),
     addprojecttype: bool = typer.Option(
         False,
@@ -471,7 +471,7 @@ def custom(
     ),
     tenant: str = typer.Option(
         "",  # Default value of comamand
-        help=f"Defaults to US tenant, add 'eu' or 'au' to use EU or AU tenant, use --tenant to change tenant.",
+        help=f"Defaults to US tenant (app.snyk.io), add 'eu', 'au' or 'us' to use alternative regional tenant. Use --tenant to change tenant.",
     ),
     addprojecttype: bool = typer.Option(
         False,
@@ -533,7 +533,7 @@ def alltargets(
     ),
     tenant: str = typer.Option(
         "",  # Default value of comamand
-        help=f"Defaults to US tenant, add 'eu' or 'au' to use EU or AU tenant, use --tenant to change tenant.",
+        help=f"Defaults to US tenant (app.snyk.io), add 'eu', 'au' or 'us' to use alternative regional tenant. Use --tenant to change tenant.",
     ),
     tagKey: str = typer.Option(
         ..., help="Tag key: identifier of the tag"  # Default value of comamand

--- a/snyk_tags/tag.py
+++ b/snyk_tags/tag.py
@@ -26,7 +26,7 @@ app = typer.Typer()
 def create_client(token: str, tenant: str) -> httpx.Client:
     base_url = (
         f"https://api.{tenant}.snyk.io/v1"
-        if tenant in ["eu", "au"]
+        if tenant in ["eu", "au", "us"]
         else "https://api.snyk.io/v1"
     )
     headers = {"Authorization": f"token {token}"}
@@ -90,7 +90,7 @@ def apply_tags_to_projects(
         for org_id in org_ids:
             base_url = (
                 f"https://api.{tenant}.snyk.io/rest"
-                if tenant in ["eu", "au"]
+                if tenant in ["eu", "au", "us"]
                 else "https://api.snyk.io/rest"
             )
             client_v3 = SnykClient(
@@ -141,7 +141,7 @@ def apply_tags_to_projects_by_name(
         for org_id in org_ids:
             base_url = (
                 f"https://api.{tenant}.snyk.io/rest"
-                if tenant in ["eu", "au"]
+                if tenant in ["eu", "au", "us"]
                 else "https://api.snyk.io/rest"
             )
             client_v3 = SnykClient(


### PR DESCRIPTION
The following functions associated with remove expect a tenant value :

- remove_tag_from_group
- remove_tag_from_project
- remove_tags_from_projects
- remove_tags_from_projects_by_name

This wasn't being supplied in the fromfile command context. This change address the issue and also adds 'us' as a [regional tenant](https://docs.snyk.io/working-with-snyk/regional-hosting-and-data-residency) option everywhere that check is being made.

